### PR TITLE
Add post-release, local version identifier fields

### DIFF
--- a/vcr/__init__.py
+++ b/vcr/__init__.py
@@ -4,7 +4,7 @@ from logging import NullHandler
 from .config import VCR
 from .record_mode import RecordMode as mode  # noqa: F401
 
-__version__ = "5.1.0"
+__version__ = "5.1.0.post1+sopel.gh-2456"
 
 logging.getLogger(__name__).addHandler(NullHandler())
 


### PR DESCRIPTION
This tweak helps distinguish our fork from the upstream 5.1.0.

Side-quest from working on sopel-irc/sopel#2671. Probably user-error, but I couldn't tell from the `pip show` output whether I had the Sopel fork of `vcrpy` or the upstream `5.1.0` since their package versions are identical.